### PR TITLE
Os independent pathsplit

### DIFF
--- a/grab/dataloader.py
+++ b/grab/dataloader.py
@@ -15,6 +15,7 @@
 
 import os
 import glob
+import pathlib
 import numpy as np
 import torch
 from torch.utils import data

--- a/grab/dataloader.py
+++ b/grab/dataloader.py
@@ -35,8 +35,8 @@ class LoadData(data.Dataset):
 
         frame_names = np.load(os.path.join(dataset_dir,ds_name, 'frame_names.npz'))['frame_names']
         self.frame_names = [os.path.join(dataset_dir, fname) for fname in frame_names]
-        self.frame_sbjs = np.asarray([name.split('/')[-3] for name in self.frame_names])
-        self.frame_objs = np.asarray([name.split('/')[-2].split('_')[0] for name in self.frame_names])
+        self.frame_sbjs = np.asarray([pathlib.PurePath(name).parts[-3] for name in self.frame_names])
+        self.frame_objs = np.asarray([pathlib.PurePath(name).parts[-2].split('_')[0] for name in self.frame_names])
 
         self.sbjs = np.unique(self.frame_sbjs)
         self.obj_info = np.load(os.path.join(dataset_dir, 'obj_info.npy'), allow_pickle=True).item()

--- a/grab/grab_preprocessing.py
+++ b/grab/grab_preprocessing.py
@@ -18,6 +18,7 @@ sys.path.append('..')
 import numpy as np
 import torch
 import os, glob
+import pathlib
 import smplx
 import argparse
 
@@ -231,7 +232,7 @@ class GRABDataSet(object):
     def process_sequences(self):
 
         for sequence in self.all_seqs:
-            subject_id = sequence.split('/')[-2]
+            subject_id = pathlib.PurePath(sequence).parts[-2]
             action_name = os.path.basename(sequence)
             object_name = action_name.split('_')[0]
 


### PR DESCRIPTION
Path splitting previously did not work in windows file separator. Rewritten to be OS independent with Python Standard Library pathlib (https://docs.python.org/3.8/library/pathlib.html). 